### PR TITLE
Allow unlimited sequence lengths during tokenization

### DIFF
--- a/book_ingestion_vsa_adapter_plus_cli.py
+++ b/book_ingestion_vsa_adapter_plus_cli.py
@@ -307,13 +307,25 @@ class InstrumentedBookAdapter: # Nicht mehr von adapter_plus.BookAdapter erben
         # torch.save kann bei BytesIO mit dem Zip-Serialisierer in seltenen Fällen
         # mit einer "unexpected pos"-Meldung abbrechen. Wir versuchen daher zuerst
         # den Standardweg und fallen bei Problemen auf das Legacy-Format zurück.
-        buffer = io.BytesIO()
+        class _NonClosingBytesIO(io.BytesIO):
+            def close(self) -> None:  # type: ignore[override]
+                # torch.save() schließt den Stream nach dem Schreiben.
+                # Für BytesIO würde das spätere getvalue() scheitern, daher ignorieren.
+                pass
+
+            def real_close(self) -> None:
+                super().close()
+
+        buffer = _NonClosingBytesIO()
         try:
             tc.torch.save(payload, buffer)
         except RuntimeError:
-            buffer = io.BytesIO()
+            buffer.real_close()
+            buffer = _NonClosingBytesIO()
             tc.torch.save(payload, buffer, _use_new_zipfile_serialization=False)
-        return buffer.getvalue()
+        data = buffer.getvalue()
+        buffer.real_close()
+        return data
 
     def import_brain_state(self, data: bytes) -> None:
         buffer = io.BytesIO(data)

--- a/book_ingestion_vsa_adapter_plus_cli.py
+++ b/book_ingestion_vsa_adapter_plus_cli.py
@@ -304,8 +304,15 @@ class InstrumentedBookAdapter: # Nicht mehr von adapter_plus.BookAdapter erben
             "step_counter": self._step_counter,
             "ingested_text_data": [list(chunk) for chunk in self.ingested_text_data],
         }
+        # torch.save kann bei BytesIO mit dem Zip-Serialisierer in seltenen Fällen
+        # mit einer "unexpected pos"-Meldung abbrechen. Wir versuchen daher zuerst
+        # den Standardweg und fallen bei Problemen auf das Legacy-Format zurück.
         buffer = io.BytesIO()
-        tc.torch.save(payload, buffer)
+        try:
+            tc.torch.save(payload, buffer)
+        except RuntimeError:
+            buffer = io.BytesIO()
+            tc.torch.save(payload, buffer, _use_new_zipfile_serialization=False)
         return buffer.getvalue()
 
     def import_brain_state(self, data: bytes) -> None:

--- a/book_ingestion_vsa_adapter_plus_cli.py
+++ b/book_ingestion_vsa_adapter_plus_cli.py
@@ -12,7 +12,6 @@ import argparse
 import csv
 import io
 import os
-import pickle
 import sys
 import time
 from dataclasses import dataclass, field
@@ -295,17 +294,26 @@ class InstrumentedBookAdapter: # Nicht mehr von adapter_plus.BookAdapter erben
             "transformer_state_dict": self.transformer_core.state_dict(),
             "optimizer_state_dict": self.trainer.optimizer.state_dict(),
             "tokenizer_name": self.tokenizer.name, # Speichere den Namen des Tokenizers
-            "metrics": self.metrics,
+            "metrics": {
+                "steps": list(self.metrics.steps),
+                "loss": list(self.metrics.loss),
+                "perplexity": list(self.metrics.perplexity),
+                "accuracy": list(self.metrics.accuracy),
+                "learning_rate": list(self.metrics.learning_rate),
+            },
             "step_counter": self._step_counter,
-            "ingested_text_data": self.ingested_text_data,
+            "ingested_text_data": [list(chunk) for chunk in self.ingested_text_data],
         }
-        return pickle.dumps(payload, protocol=pickle.HIGHEST_PROTOCOL)
+        buffer = io.BytesIO()
+        tc.torch.save(payload, buffer)
+        return buffer.getvalue()
 
     def import_brain_state(self, data: bytes) -> None:
-        payload = pickle.loads(data)
+        buffer = io.BytesIO(data)
+        payload = tc.torch.load(buffer, map_location=self.device)
         if not isinstance(payload, dict):
             raise ValueError("Ungültiges Gehirnformat: Erwartet Wörterbuch.")
-        
+
         # Laden des Transformer-Modells
         self.transformer_core.load_state_dict(payload.pop("transformer_state_dict", {}))
         
@@ -328,9 +336,23 @@ class InstrumentedBookAdapter: # Nicht mehr von adapter_plus.BookAdapter erben
         self.trainer.model = self.transformer_core
         self.trainer.device = self.device
         
-        self.metrics = payload.pop("metrics", MetricsLogger())
+        metrics_payload = payload.pop("metrics", None)
+        if isinstance(metrics_payload, dict):
+            metrics = MetricsLogger()
+            metrics.steps = list(metrics_payload.get("steps", []))
+            metrics.loss = list(metrics_payload.get("loss", []))
+            metrics.perplexity = list(metrics_payload.get("perplexity", []))
+            metrics.accuracy = list(metrics_payload.get("accuracy", []))
+            metrics.learning_rate = list(metrics_payload.get("learning_rate", []))
+            self.metrics = metrics
+        elif isinstance(metrics_payload, MetricsLogger):
+            # Fallback für ältere Speicherstände
+            self.metrics = metrics_payload
+        else:
+            self.metrics = MetricsLogger()
         self._step_counter = int(payload.pop("step_counter", 0))
-        self.ingested_text_data = payload.pop("ingested_text_data", [])
+        ingested_payload = payload.pop("ingested_text_data", [])
+        self.ingested_text_data = [list(chunk) for chunk in ingested_payload]
 
         # Falls importierte Metriken leer sind, aktuellen Zustand loggen, damit UI Werte hat.
         if not self.metrics.steps:

--- a/book_ingestion_vsa_adapter_plus_cli.py
+++ b/book_ingestion_vsa_adapter_plus_cli.py
@@ -151,20 +151,27 @@ class InstrumentedBookAdapter: # Nicht mehr von adapter_plus.BookAdapter erben
         criterion: Optional[tc.torch.nn.Module] = None,
         device: Optional[tc.torch.device] = None
     ):
-        self.transformer_core = transformer_core
         self.tokenizer = tokenizer
         self.metrics = MetricsLogger()
         self._step_counter = 0
         self._metric_callbacks: List[Callable[[Dict[str, float]], None]] = []
         self.ingested_text_data: List[List[int]] = [] # Tokenisierte Daten
 
+        self.device = device or tc.torch.device("cuda" if tc.torch.cuda.is_available() else "cpu")
+        self.transformer_core = transformer_core.to(self.device)
+
+        if optimizer is None:
+            optimizer = tc.torch.optim.Adam(self.transformer_core.parameters(), lr=1e-4)
+        if criterion is None:
+            criterion = tc.torch.nn.CrossEntropyLoss(ignore_index=tokenizer.pad_token_id)
+
         # Initialisiere den Trainer mit allen erforderlichen Parametern
         self.trainer = tc.TransformerTrainer(
-            model=transformer_core,
-            optimizer=optimizer, # Kann None sein, Trainer initialisiert Standard, wenn nicht gegeben
-            criterion=criterion, # Kann None sein, Trainer initialisiert Standard, wenn nicht gegeben
-            device=device,       # Kann None sein, Trainer wählt Standard, wenn nicht gegeben
-            tokenizer=tokenizer  # Tokenizer ist für Metriken im Trainer nützlich
+            model=self.transformer_core,
+            optimizer=optimizer,
+            criterion=criterion,
+            device=self.device,
+            tokenizer=tokenizer
         )
 
     def add_metric_callback(self, cb: Callable[[Dict[str, float]], None]) -> None:
@@ -213,7 +220,8 @@ class InstrumentedBookAdapter: # Nicht mehr von adapter_plus.BookAdapter erben
         # Der `adapter_plus` könnte hier für die Segmentierung in Sätze/Absätze helfen,
         # bevor der Tokenizer des Transformers angewendet wird.
         # Für eine einfache Implementierung: gesamter Text wird tokenisiert.
-        token_ids = self.tokenizer.encode(text)
+        token_tensor = self.tokenizer.encode(text, truncation=False, padding='do_not_pad')
+        token_ids = token_tensor.squeeze(0).tolist()
         self.ingested_text_data.append(token_ids) # Speichern der tokenisierten Daten
 
         # Anfangslog (mit 0-Werten, da noch kein Training)
@@ -228,26 +236,55 @@ class InstrumentedBookAdapter: # Nicht mehr von adapter_plus.BookAdapter erben
 
         print(f"Starte Training für {epochs} Epochen...")
         all_token_ids = [token for sublist in self.ingested_text_data for token in sublist]
-        
+        total_tokens = len(all_token_ids)
+        if total_tokens < 2:
+            print("Zu wenige Tokens für das Training.")
+            return
+
+        max_seq_len = self.transformer_core.pos_encoder.pe.size(0)
+        seq_len = max(2, min(max_seq_len, total_tokens - 1))
+        pad_id = self.tokenizer.pad_token_id if self.tokenizer.pad_token_id is not None else 0
+
+        input_chunks: List[List[int]] = []
+        target_chunks: List[List[int]] = []
+        for start in range(0, total_tokens - 1, seq_len):
+            end = min(start + seq_len, total_tokens - 1)
+            input_chunk = all_token_ids[start:end]
+            target_chunk = all_token_ids[start + 1:end + 1]
+            if len(input_chunk) < seq_len:
+                input_chunk = input_chunk + [pad_id] * (seq_len - len(input_chunk))
+            if len(target_chunk) < seq_len:
+                target_chunk = target_chunk + [pad_id] * (seq_len - len(target_chunk))
+            input_chunks.append(input_chunk)
+            target_chunks.append(target_chunk)
+
+        input_tensor = tc.torch.tensor(input_chunks, dtype=tc.torch.long)
+        target_tensor = tc.torch.tensor(target_chunks, dtype=tc.torch.long)
+        dataset = tc.torch.utils.data.TensorDataset(input_tensor, target_tensor)
+        dataloader = tc.torch.utils.data.DataLoader(dataset, batch_size=batch_size, shuffle=True)
+
         # Setze die Trainingsdaten im Trainer
-        self.trainer.set_training_data(all_token_ids)
+        self.trainer.set_training_data(dataloader)
         self.trainer.set_learning_rate(learning_rate)
 
         for epoch in range(epochs):
             print(f"Epoche {epoch+1}/{epochs}")
-            # Der Trainer kümmert sich um Batches und den Trainingsschritt
-            for loss, ppl, acc, lr in self.trainer.train_epoch(batch_size):
+            for loss, ppl, acc, lr in self.trainer.train_batches():
                 self._step_counter += 1
                 self._log_now(loss, ppl, acc, lr)
                 if self._step_counter % 10 == 0:
                     print(f"  Schritt {self._step_counter}: Loss={loss:.4f}, PPL={ppl:.2f}, Acc={acc:.2f}")
         print("Training abgeschlossen.")
 
-    def generate_text(self, prompt: str, max_length: int = 50) -> str:
+    def generate_text(self, prompt: str, max_length: int = 50, temperature: float = 1.0) -> str:
         """Generiert Text basierend auf einem Prompt."""
         print(f"Generiere Text mit Prompt: '{prompt}'...")
-        input_ids = self.tokenizer.encode(prompt)
-        generated_ids = self.transformer_core.generate(input_ids, max_length=max_length)
+        input_ids = self.tokenizer.encode(prompt, truncation=False, padding='do_not_pad').to(self.device)
+        generated_ids = self.transformer_core.generate_text(
+            input_ids,
+            max_new_tokens=max_length,
+            temperature=temperature,
+        )
         generated_text = self.tokenizer.decode(generated_ids)
         
         return generated_text
@@ -275,20 +312,21 @@ class InstrumentedBookAdapter: # Nicht mehr von adapter_plus.BookAdapter erben
         # Laden des Optimierers
         optimizer_state_dict = payload.pop("optimizer_state_dict", None)
         if optimizer_state_dict:
-            # Der Trainer muss den Optimierer neu initialisieren, bevor er den Zustand lädt
-            # oder der Optimierer muss direkt im Trainer gesetzt werden.
-            # Hier wird angenommen, dass der Trainer eine Methode zum Laden des Optimiererzustands hat.
-            # Alternativ könnte der Optimierer hier neu erstellt und dann geladen werden.
-            # Da der Trainer den Optimierer verwaltet, rufen wir seine Methode auf.
             self.trainer.load_optimizer_state_dict(optimizer_state_dict)
-        
+
         # Laden des Tokenizers (ggf. neu initialisieren)
         tokenizer_name = payload.pop("tokenizer_name", None)
         if tokenizer_name:
             # Annahme: Tokenizer kann mit einem Namen neu initialisiert werden
-            self.tokenizer = tc.Tokenizer(tokenizer_name=tokenizer_name)
+            self.tokenizer = tc.Tokenizer(pretrained_model_name_or_path=tokenizer_name)
             # Aktualisiere den Tokenizer im Trainer, falls dieser ihn auch hält
             self.trainer.tokenizer = self.tokenizer
+            if isinstance(self.trainer.criterion, tc.torch.nn.CrossEntropyLoss):
+                self.trainer.criterion = tc.torch.nn.CrossEntropyLoss(ignore_index=self.tokenizer.pad_token_id)
+
+        self.transformer_core.to(self.device)
+        self.trainer.model = self.transformer_core
+        self.trainer.device = self.device
         
         self.metrics = payload.pop("metrics", MetricsLogger())
         self._step_counter = int(payload.pop("step_counter", 0))

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -140,11 +140,11 @@ def _create_adapter(metric_queue: queue.Queue) -> InstrumentedBookAdapter:
 
     # Übergabe aller benötigten Parameter an den InstrumentedBookAdapter
     adapter = InstrumentedBookAdapter(
-        model=model,
+        transformer_core=model,
+        tokenizer=tokenizer,
         optimizer=optimizer,
         criterion=criterion,
         device=st.session_state.device,
-        tokenizer=tokenizer
     )
     adapter.clear_metric_callbacks()
 
@@ -152,8 +152,8 @@ def _create_adapter(metric_queue: queue.Queue) -> InstrumentedBookAdapter:
         metric_queue.put(snapshot)
 
     adapter.add_metric_callback(_emit)
-    st.session_state.transformer_core = model # Speichern des Modells
-    st.session_state.tokenizer = tokenizer # Speichern des Tokenizers
+    st.session_state.transformer_core = adapter.transformer_core # Speichern des Modells
+    st.session_state.tokenizer = adapter.tokenizer # Speichern des Tokenizers
     st.session_state.adapter = adapter
     return adapter
 
@@ -165,7 +165,7 @@ def _attach_adapter(adapter: InstrumentedBookAdapter, metric_queue: queue.Queue)
         metric_queue.put(snapshot)
 
     adapter.add_metric_callback(_emit)
-    st.session_state.transformer_core = adapter.model # Speichern des Modells
+    st.session_state.transformer_core = adapter.transformer_core # Speichern des Modells
     st.session_state.tokenizer = adapter.tokenizer # Speichern des Tokenizers
     st.session_state.adapter = adapter
 
@@ -187,12 +187,11 @@ def _start_training(text: str, epochs: int, batch_size: int, learning_rate: floa
         status_queue.put({"type": "status", "value": "Training läuft..."})
         try:
             # Aufruf der Transformer-spezifischen Trainingsmethode
-            adapter.train_on_ingested_data( # Korrigierter Methodenname
-                text,
+            adapter.ingest_book(text, reset_state=not append)
+            adapter.train_on_ingested_data(
                 epochs=epochs,
                 batch_size=batch_size,
                 learning_rate=learning_rate,
-                reset_optimizer=not append, # Optimierer nur zurücksetzen, wenn nicht angefügt
             )
             status_queue.put({"type": "status", "value": "Training abgeschlossen"})
         except Exception as exc:  # pragma: no cover - nur zur Anzeige in der UI
@@ -352,7 +351,7 @@ def _render_persistence() -> None:
         st.subheader("Aktuellen Zustand sichern")
         if adapter:
             try:
-                model_bytes = adapter.export_model_state()
+                model_bytes = adapter.export_brain_state()
             except Exception as exc:  # pragma: no cover - Schutz vor Serialisierungsfehlern
                 st.error(f"Export fehlgeschlagen: {exc}")
                 model_bytes = None
@@ -391,9 +390,9 @@ def _render_persistence() -> None:
                         state.status_queue = status_queue
                         # Erstellt einen neuen Adapter mit Standard-Modell/Tokenizer,
                         # dessen Zustand dann überschrieben wird.
-                        adapter = _create_adapter(metrics_queue) 
-                        adapter.import_model_state(data) # Lädt den Zustand in den neuen Adapter
-                        state.transformer_core = adapter.model # Speichern des Modells
+                        adapter = _create_adapter(metrics_queue)
+                        adapter.import_brain_state(data) # Lädt den Zustand in den neuen Adapter
+                        state.transformer_core = adapter.transformer_core # Speichern des Modells
                         state.tokenizer = adapter.tokenizer # Speichern des Tokenizers
                         state.metrics_history = adapter.metrics.as_dicts()
                         state.training_status = "Modell geladen"

--- a/transformer_core.py
+++ b/transformer_core.py
@@ -19,16 +19,30 @@ class Tokenizer:
         # Füge ein Padding-Token hinzu, falls nicht vorhanden, und setze es als pad_token
         if self.tokenizer.pad_token is None:
             self.tokenizer.add_special_tokens({'pad_token': '[PAD]'})
+        # Einige Tokenizer (z. B. GPT2) besitzen eine harte Standard-Limitierung von 1024
+        # Token. Für unser Training auf langen Büchern ist das kontraproduktiv, daher wird
+        # die maximale Sequenzlänge auf einen sehr großen Wert gesetzt. Dies verhindert
+        # Warnungen und – kombiniert mit deaktivierter Trunkierung – das Abschneiden
+        # langer Texte während der Ingestion.
+        try:
+            self.tokenizer.model_max_length = int(1e9)
+            if hasattr(self.tokenizer, "init_kwargs"):
+                self.tokenizer.init_kwargs["model_max_length"] = int(1e9)
+        except Exception:
+            # Falls der Tokenizer diese Attribute nicht kennt, ignorieren – es handelt
+            # sich nur um einen Schutz gegen aggressive Kürzungen.
+            pass
         # Stelle sicher, dass das Modell die neue Vokabulargröße kennt, falls der Tokenizer erweitert wurde.
         # Dies muss im Modell selbst gehandhabt werden, wenn es initialisiert wird.
 
-    def encode(self, text: str, max_length: int = None, truncation: bool = True, padding: str = 'max_length') -> torch.Tensor:
+    def encode(self, text: str, max_length: int = None, truncation: bool = False, padding: str = 'longest') -> torch.Tensor:
         """
         Kodiert einen Text in Token-IDs.
         Args:
             text: Der zu kodierende Text.
-            max_length: Maximale Sequenzlänge.
-            truncation: Ob der Text abgeschnitten werden soll, wenn er länger als max_length ist.
+            max_length: Maximale Sequenzlänge. Wenn ``None`` wird keine harte Grenze gesetzt.
+            truncation: Ob der Text abgeschnitten werden soll. Standardmäßig deaktiviert,
+                damit ganze Bücher ingestiert werden können.
             padding: Padding-Strategie ('max_length', 'longest', 'do_not_pad').
         Returns:
             Ein Tensor von Token-IDs.
@@ -78,24 +92,40 @@ class Tokenizer:
 class PositionalEncoding(nn.Module):
     """
     Fügt Positionsinformationen zu den Eingabe-Embeddings hinzu.
+
+    Die ursprüngliche Implementierung war auf eine feste maximale Sequenzlänge begrenzt.
+    Für Buchlängen von weit über 100k Tokens wird die Positional Encoding nun dynamisch
+    erweitert, sobald längere Sequenzen beobachtet werden.
     """
+
     def __init__(self, d_model: int, dropout: float = 0.1, max_len: int = 5000):
         super().__init__()
         self.dropout = nn.Dropout(p=dropout)
+        self.d_model = d_model
+        self.register_buffer('pe', self._build_pe(max_len), persistent=False)
 
-        position = torch.arange(max_len).unsqueeze(1)
-        div_term = torch.exp(torch.arange(0, d_model, 2) * (-math.log(10000.0) / d_model))
-        pe = torch.zeros(max_len, 1, d_model)
+    def _build_pe(self, length: int, device: torch.device | None = None) -> torch.Tensor:
+        position = torch.arange(length, device=device).unsqueeze(1)
+        div_term = torch.exp(torch.arange(0, self.d_model, 2, device=device) * (-math.log(10000.0) / self.d_model))
+        pe = torch.zeros(length, 1, self.d_model, device=device)
         pe[:, 0, 0::2] = torch.sin(position * div_term)
         pe[:, 0, 1::2] = torch.cos(position * div_term)
-        self.register_buffer('pe', pe)
+        return pe
+
+    def _ensure_length(self, seq_len: int, device: torch.device) -> None:
+        if self.pe is None or self.pe.size(0) >= seq_len:
+            return
+        new_pe = self._build_pe(seq_len, device=device)
+        self.register_buffer('pe', new_pe, persistent=False)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """
         Args:
             x: Tensor, shape [seq_len, batch_size, embed_dim]
         """
-        x = x + self.pe[:x.size(0)]
+        seq_len = x.size(0)
+        self._ensure_length(seq_len, x.device)
+        x = x + self.pe[:seq_len]
         return self.dropout(x)
 
 class MultiHeadSelfAttention(nn.Module):
@@ -403,12 +433,6 @@ class TransformerTrainer:
         current_input_ids = prompt_ids.to(self.device)
 
         for _ in range(max_new_tokens):
-            # Beschränke die Eingabesequenz auf die maximale Sequenzlänge des Modells
-            # Dies ist wichtig, da PositionalEncoding eine feste max_len hat
-            max_model_seq_len = self.model.pos_encoder.pe.size(0)
-            if current_input_ids.size(1) > max_model_seq_len:
-                current_input_ids = current_input_ids[:, -max_model_seq_len:]
-
             with torch.no_grad():
                 output = self.model(current_input_ids) # [1, current_seq_len, vocab_size]
 

--- a/transformer_core.py
+++ b/transformer_core.py
@@ -2,6 +2,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 import math
+from typing import Iterator
 from transformers import AutoTokenizer
 from torch.utils.data import DataLoader
 
@@ -288,6 +289,12 @@ class TransformerTrainer:
         self.data_loader: DataLoader = None # Wird später mit Trainingsdaten gesetzt
         self.learning_rate = optimizer.param_groups[0]['lr'] # Initialisiere Lernrate
 
+    def load_optimizer_state_dict(self, state_dict: dict) -> None:
+        """Lädt einen gespeicherten Optimiererzustand."""
+        self.optimizer.load_state_dict(state_dict)
+        if self.optimizer.param_groups:
+            self.learning_rate = self.optimizer.param_groups[0]['lr']
+
     def reset_optimizer(self, learning_rate: float = None):
         """
         Setzt den Optimierer mit der aktuellen oder einer neuen Lernrate zurück.
@@ -313,14 +320,14 @@ class TransformerTrainer:
         self.data_loader = data_loader
         print(f"Trainingsdaten-Loader gesetzt. Anzahl der Batches: {len(self.data_loader) if self.data_loader else 0}")
 
-    def train_step(self, input_ids: torch.Tensor, target_ids: torch.Tensor) -> float:
+    def train_step(self, input_ids: torch.Tensor, target_ids: torch.Tensor) -> tuple[float, float, float]:
         """
         Führt einen einzelnen Trainingsschritt durch.
         Args:
             input_ids: Batch von Eingabe-Token-IDs, shape [batch_size, seq_len]
             target_ids: Batch von Ziel-Token-IDs, shape [batch_size, seq_len]
         Returns:
-            Verlustwert für diesen Schritt.
+            Tupel aus (Loss, Perplexity, Accuracy) für diesen Schritt.
         """
         self.model.train()
         self.optimizer.zero_grad()
@@ -337,12 +344,28 @@ class TransformerTrainer:
         # target_ids: [batch_size * seq_len]
         loss = self.criterion(output.view(-1, output.size(-1)), target_ids.view(-1))
 
+        loss_value = loss.item()
+        with torch.no_grad():
+            predictions = output.argmax(dim=-1)
+            pad_token_id = self.tokenizer.pad_token_id
+            if pad_token_id is not None:
+                mask = target_ids != pad_token_id
+                valid_tokens = mask.sum().item()
+                if valid_tokens > 0:
+                    correct_tokens = (predictions == target_ids) & mask
+                    accuracy = correct_tokens.sum().item() / valid_tokens
+                else:
+                    accuracy = 0.0
+            else:
+                accuracy = (predictions == target_ids).float().mean().item()
+        perplexity = math.exp(min(loss_value, 20.0))
+
         loss.backward()
         # Optional: Gradient Clipping
         torch.nn.utils.clip_grad_norm_(self.model.parameters(), 1.0)
         self.optimizer.step()
 
-        return loss.item()
+        return loss_value, perplexity, accuracy
 
     def train_epoch(self) -> float:
         """
@@ -358,7 +381,7 @@ class TransformerTrainer:
         num_batches = 0
 
         for batch_idx, (input_ids, target_ids) in enumerate(self.data_loader):
-            loss = self.train_step(input_ids, target_ids)
+            loss, _, _ = self.train_step(input_ids, target_ids)
             total_loss += loss
             num_batches += 1
             # Optional: Fortschritt ausgeben
@@ -367,6 +390,19 @@ class TransformerTrainer:
 
         avg_loss = total_loss / num_batches if num_batches > 0 else 0
         return avg_loss
+
+    def train_batches(self) -> Iterator[tuple[float, float, float, float]]:
+        """
+        Iteriert über den aktuellen DataLoader und liefert Metriken je Batch.
+        Returns:
+            Iterator über Tupel (Loss, Perplexity, Accuracy, Learning Rate).
+        """
+        if self.data_loader is None:
+            raise ValueError("Trainingsdaten-Loader wurde nicht gesetzt. Bitte rufen Sie 'set_training_data' auf.")
+
+        for input_ids, target_ids in self.data_loader:
+            loss, perplexity, accuracy = self.train_step(input_ids, target_ids)
+            yield loss, perplexity, accuracy, self.optimizer.param_groups[0]['lr']
 
     def evaluate_step(self, input_ids: torch.Tensor, target_ids: torch.Tensor) -> float:
         """

--- a/transformer_core.py
+++ b/transformer_core.py
@@ -148,17 +148,23 @@ class MultiHeadSelfAttention(nn.Module):
         self.dropout = nn.Dropout(dropout)
 
     def forward(self, query: torch.Tensor, key: torch.Tensor, value: torch.Tensor, mask: torch.Tensor = None) -> torch.Tensor:
-        batch_size = query.size(0)
+        """Führt Multi-Head Self-Attention auf sequenz-erster Eingabe aus."""
+
+        # Die Transformer-Architektur in dieser Datei arbeitet sequenz-erste
+        # ([seq_len, batch_size, d_model]). Für die Aufteilung in Attention-Köpfe
+        # konvertieren wir temporär in die Batch-First-Repräsentation.
+        seq_len, batch_size, _ = query.size()
 
         # 1) Lineare Transformationen und Aufteilung in Köpfe
-        query = self.q_linear(query).view(batch_size, -1, self.num_heads, self.d_k).transpose(1, 2)
-        key = self.k_linear(key).view(batch_size, -1, self.num_heads, self.d_k).transpose(1, 2)
-        value = self.v_linear(value).view(batch_size, -1, self.num_heads, self.d_k).transpose(1, 2)
+        query = self.q_linear(query).view(seq_len, batch_size, self.num_heads, self.d_k).permute(1, 2, 0, 3)
+        key = self.k_linear(key).view(seq_len, batch_size, self.num_heads, self.d_k).permute(1, 2, 0, 3)
+        value = self.v_linear(value).view(seq_len, batch_size, self.num_heads, self.d_k).permute(1, 2, 0, 3)
 
         # 2) Skaliertes Dot-Product Attention
         scores = torch.matmul(query, key.transpose(-2, -1)) / math.sqrt(self.d_k)
 
         if mask is not None:
+            # Erlaube Broadcast über Batch- und Kopf-Dimensionen.
             scores = scores.masked_fill(mask == 0, -1e9) # Maskiere unerwünschte Verbindungen
 
         attention_weights = F.softmax(scores, dim=-1)
@@ -166,8 +172,8 @@ class MultiHeadSelfAttention(nn.Module):
 
         output = torch.matmul(attention_weights, value)
 
-        # 3) Konkatenation der Köpfe und finale lineare Transformation
-        output = output.transpose(1, 2).contiguous().view(batch_size, -1, self.d_model)
+        # 3) Rücktransponieren in sequenz-erste Darstellung und finale lineare Transformation
+        output = output.permute(2, 0, 1, 3).contiguous().view(seq_len, batch_size, self.d_model)
         output = self.out_linear(output)
         return output
 

--- a/transformer_core.py
+++ b/transformer_core.py
@@ -156,9 +156,9 @@ class MultiHeadSelfAttention(nn.Module):
         seq_len, batch_size, _ = query.size()
 
         # 1) Lineare Transformationen und Aufteilung in Köpfe
-        query = self.q_linear(query).view(seq_len, batch_size, self.num_heads, self.d_k).permute(1, 2, 0, 3)
-        key = self.k_linear(key).view(seq_len, batch_size, self.num_heads, self.d_k).permute(1, 2, 0, 3)
-        value = self.v_linear(value).view(seq_len, batch_size, self.num_heads, self.d_k).permute(1, 2, 0, 3)
+        query = self.q_linear(query).reshape(seq_len, batch_size, self.num_heads, self.d_k).permute(1, 2, 0, 3)
+        key = self.k_linear(key).reshape(seq_len, batch_size, self.num_heads, self.d_k).permute(1, 2, 0, 3)
+        value = self.v_linear(value).reshape(seq_len, batch_size, self.num_heads, self.d_k).permute(1, 2, 0, 3)
 
         # 2) Skaliertes Dot-Product Attention
         scores = torch.matmul(query, key.transpose(-2, -1)) / math.sqrt(self.d_k)
@@ -173,7 +173,7 @@ class MultiHeadSelfAttention(nn.Module):
         output = torch.matmul(attention_weights, value)
 
         # 3) Rücktransponieren in sequenz-erste Darstellung und finale lineare Transformation
-        output = output.permute(2, 0, 1, 3).contiguous().view(seq_len, batch_size, self.d_model)
+        output = output.permute(2, 0, 1, 3).contiguous().reshape(seq_len, batch_size, self.d_model)
         output = self.out_linear(output)
         return output
 
@@ -348,7 +348,7 @@ class TransformerTrainer:
         # Für die Verlustberechnung müssen wir die Dimensionen anpassen
         # output: [batch_size * seq_len, vocab_size]
         # target_ids: [batch_size * seq_len]
-        loss = self.criterion(output.view(-1, output.size(-1)), target_ids.view(-1))
+        loss = self.criterion(output.reshape(-1, output.size(-1)), target_ids.reshape(-1))
 
         loss_value = loss.item()
         with torch.no_grad():
@@ -425,7 +425,7 @@ class TransformerTrainer:
 
         with torch.no_grad():
             output = self.model(input_ids)
-            loss = self.criterion(output.view(-1, output.size(-1)), target_ids.view(-1))
+            loss = self.criterion(output.reshape(-1, output.size(-1)), target_ids.reshape(-1))
         return loss.item()
 
     def save_model(self, path: str):


### PR DESCRIPTION
## Summary
- disable tokenizer truncation by default and raise the internal model_max_length so complete books can be ingested without hard clipping
- make the sinusoidal positional encoding grow on demand to support sequences well beyond the previous static limit
- allow text generation to reuse the full context without slicing it back to the former maximum length

## Testing
- python -m compileall transformer_core.py

------
https://chatgpt.com/codex/tasks/task_e_68d0d79f8f088325a1705c6eb43d075e